### PR TITLE
DFSound: Fix reverb (pcercuei)

### DIFF
--- a/dfsound/registers.c
+++ b/dfsound/registers.c
@@ -22,14 +22,7 @@
 #include "externals.h"
 #include "registers.h"
 #include "spu_config.h"
-
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#define HTOLE16(x) __builtin_bswap16(x)
-#define LE16TOH(x) __builtin_bswap16(x)
-#else
-#define HTOLE16(x) (x)
-#define LE16TOH(x) (x)
-#endif
+#include "spu.h"
 
 static void SoundOn(int start,int end,unsigned short val);
 static void SoundOff(int start,int end,unsigned short val);

--- a/dfsound/reverb.c
+++ b/dfsound/reverb.c
@@ -20,6 +20,7 @@
  ***************************************************************************/
 
 #include "stdafx.h"
+#include "spu.h"
 
 #define _IN_REVERB
 
@@ -50,16 +51,16 @@ INLINE int rvb2ram_offs(int curr, int space, int iOff)
 
 // get_buffer content helper: takes care about wraps
 #define g_buffer(var) \
- ((int)(signed short)spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var)])
+ ((int)(signed short)LE16TOH(spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var)]))
 
 // saturate iVal and store it as var
 #define s_buffer(var, iVal) \
  ssat32_to_16(iVal); \
- spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var)] = iVal
+ spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var)] = HTOLE16(iVal)
 
 #define s_buffer1(var, iVal) \
  ssat32_to_16(iVal); \
- spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var + 1)] = iVal
+ spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var + 1)] = HTOLE16(iVal)
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/dfsound/spu.h
+++ b/dfsound/spu.h
@@ -18,6 +18,14 @@
 #ifndef __P_SPU_H__
 #define __P_SPU_H__
 
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define HTOLE16(x) __builtin_bswap16(x)
+#define LE16TOH(x) __builtin_bswap16(x)
+#else
+#define HTOLE16(x) (x)
+#define LE16TOH(x) (x)
+#endif
+
 void ClearWorkingState(void);
 void CALLBACK SPUplayADPCMchannel(xa_decode_t *xap, unsigned int cycle, int is_start);
 int  CALLBACK SPUplayCDDAchannel(short *pcm, int bytes, unsigned int cycle, int is_start);

--- a/dfsound/xa.c
+++ b/dfsound/xa.c
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "stdafx.h"
+#include "spu.h"
 #define _IN_XA
 #include <stdint.h>
 
@@ -60,8 +61,8 @@ INLINE void MixXA(int *SSumLR, int ns_to, int decode_pos)
     SSumLR[ns++] += l;
     SSumLR[ns++] += r;
 
-    spu.spuMem[cursor] = v;
-    spu.spuMem[cursor + 0x400/2] = v >> 16;
+    spu.spuMem[cursor] = HTOLE16(v);
+    spu.spuMem[cursor + 0x400/2] = HTOLE16(v >> 16);
     cursor = (cursor + 1) & 0x1ff;
    }
   spu.XALastVal = v;
@@ -80,8 +81,8 @@ INLINE void MixXA(int *SSumLR, int ns_to, int decode_pos)
     SSumLR[ns++] += l;
     SSumLR[ns++] += r;
 
-    spu.spuMem[cursor] = v;
-    spu.spuMem[cursor + 0x400/2] = v >> 16;
+    spu.spuMem[cursor] = HTOLE16(v);
+    spu.spuMem[cursor + 0x400/2] = HTOLE16(v >> 16);
     cursor = (cursor + 1) & 0x1ff;
    }
   spu.XALastVal = v;


### PR DESCRIPTION
Fix the reverb code to work on big-endian systems (such the Wii).

According to pcercuei, this fix also fixes reverb code for work on big-endian systems (Wii in this case), so now the BIOS music and the game Vib-Ribbon (which uses reverb) work fine.

Upstream PCSX-ReARMed PR: https://github.com/notaz/pcsx_rearmed/pull/292

PCSXGC PR reference: https://github.com/emukidid/pcsxgc/pull/16